### PR TITLE
exam-02 alias実装

### DIFF
--- a/02/conf.d/alias.conf
+++ b/02/conf.d/alias.conf
@@ -1,0 +1,7 @@
+<IfModule alias_module>
+Alias /images /var/www/html/assets
+<Directory /var/www/html/assets>
+    Order allow,deny
+    Allow from all
+</Directory>
+</IfModule>

--- a/02/scripts/provision.sh
+++ b/02/scripts/provision.sh
@@ -4,6 +4,12 @@ set -eu
 yum -y update
 yum -y install ntp httpd
 
-sed -i -e "s/Listen 80/Listen 8080/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/^Listen 80$/Listen 8080/g" /etc/httpd/conf/httpd.conf
 sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:8080/g" /etc/httpd/conf/httpd.conf
+
+sed -i -e "s/#EnableMMAP off/EnableMMAP off/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/#EnableSendfile off/EnableSendfile off/g" /etc/httpd/conf/httpd.conf
+sed -i -e '/Options/s/ Indexes / -Indexes /g' /etc/httpd/conf/httpd.conf
+
+cp /vagrant/conf.d/alias.conf /etc/httpd/conf.d/alias.conf
 


### PR DESCRIPTION
apacheのaliasで/imagesへのリクエストに対して/var/www/html/assetsを返すことで対応しました。

■参考資料
・NFS マウントされた DocumentRoot対応
https://httpd.apache.org/docs/2.2/ja/mod/core.html#enablemmap
https://httpd.apache.org/docs/2.2/ja/mod/core.html#enablesendfile

・Alias設定
https://httpd.apache.org/docs/2.2/ja/mod/mod_alias.html#alias
http://blog.ko-atrandom.com/?p=434

・sedの使い方
http://bi.biopapyrus.net/linux/sed.html
