### PR TITLE
exam-02 proxy実装

### DIFF
--- a/02/scripts/provision.sh
+++ b/02/scripts/provision.sh
@@ -4,6 +4,16 @@ set -eu
 yum -y update
 yum -y install ntp httpd
 
-sed -i -e "s/Listen 80/Listen 8080/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/^Listen 80$/Listen 8080/g" /etc/httpd/conf/httpd.conf
 sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:8080/g" /etc/httpd/conf/httpd.conf
 
+sed -i -e "s/#EnableMMAP off/EnableMMAP off/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/#EnableSendfile off/EnableSendfile off/g" /etc/httpd/conf/httpd.conf
+sed -i -e '/Options/s/ Indexes / -Indexes /g' /etc/httpd/conf/httpd.conf
+
+# プロキシ設定がなければ追加 
+PROXY_PASS="ProxyPass /images http://localhost:8080/assets"
+CONF_PATH="/etc/httpd/conf/httpd.conf"
+if ! grep -q "$PROXY_PASS" "$CONF_PATH"; then
+  sed -i -e "$ a $PROXY_PASS" "$CONF_PATH"
+fi


### PR DESCRIPTION
大森です。

apacheのproxy設定で/imagesへのリクエストをlocalhost:8080/assetsにプロキシすることで対応しました

レビューをお願い致します。

■参考資料
・NFS マウントされた DocumentRoot対応
https://httpd.apache.org/docs/2.2/ja/mod/core.html#enablemmap
https://httpd.apache.org/docs/2.2/ja/mod/core.html#enablesendfile

・proxy設定
https://httpd.apache.org/docs/2.2/ja/mod/mod_proxy.html#examples

・sedの使い方
http://bi.biopapyrus.net/linux/sed.html
http://qiita.com/tukiyo3/items/f75561a0cfbb7c2eedc9

・特定文字列の有無確認
http://stackoverflow.com/questions/3943854/grep-in-if-statement
