### PR TITLE
exam_02_ex

### DIFF
--- a/02/scripts/provision.sh
+++ b/02/scripts/provision.sh
@@ -2,10 +2,23 @@
 set -eu
 
 yum -y update
-yum -y install ntp httpd
+yum -y install ntp httpd httpd-devel
 
 sed -i -e "s/Listen 80/Listen 8088/g" /etc/httpd/conf/httpd.conf
 sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:8088/g" /etc/httpd/conf/httpd.conf
+
+mkdir /etc/httpd/modules/mod_rpaf-0.6
+pushd /etc/httpd/modules/mod_rpaf-0.6
+wget https://raw.github.com/ttkzw/mod_rpaf-0.6/master/mod_rpaf-2.0.c
+/usr/sbin/apxs -i -c -n mod_rpaf-2.0.so mod_rpaf-2.0.c
+popd
+cat << EOT | tee /etc/httpd/conf.d/mod_rpaf.conf > /dev/null
+LoadModule rpaf_module modules/mod_rpaf-2.0.so
+RPAFenable On
+RPAFsethostname On
+RPAFproxy_ips 127.0.0.1
+RPAFheader X-Forwarded-For
+EOT
 
 rpm -ivh http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm
 yum -y install nginx
@@ -20,10 +33,13 @@ server {
 
   location /images/ {
     root   /var/www/html;
-    rewrite /images/(.*)$ /assets/\$1;
+    rewrite /images/(.*)$ /assets/\$1 break;
   }
 
   location / {
+    proxy_set_header  X-Real-IP       \$remote_addr;
+    proxy_set_header  X-Forwarded-For \$remote_addr;
+    proxy_set_header  Host            \$http_host;
     proxy_pass http://web-apache/;
   }
 }

--- a/02/scripts/provision.sh
+++ b/02/scripts/provision.sh
@@ -4,6 +4,28 @@ set -eu
 yum -y update
 yum -y install ntp httpd
 
-sed -i -e "s/Listen 80/Listen 8080/g" /etc/httpd/conf/httpd.conf
-sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:8080/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/Listen 80/Listen 8088/g" /etc/httpd/conf/httpd.conf
+sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:8088/g" /etc/httpd/conf/httpd.conf
+
+rpm -ivh http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm
+yum -y install nginx
+
+cat << EOT | tee /etc/nginx/conf.d/r_proxy.conf > /dev/null
+upstream web-apache {
+  server localhost:8088;
+}
+server {
+  listen       8080;
+  server_name  r_proxy_nginx.jp;
+
+  location /images/ {
+    root   /var/www/html;
+    rewrite /images/(.*)$ /assets/\$1;
+  }
+
+  location / {
+    proxy_pass http://web-apache/;
+  }
+}
+EOT
 

--- a/02/scripts/run.sh
+++ b/02/scripts/run.sh
@@ -24,3 +24,10 @@ if [ "$IS_HTTPD_RUNNING" == 'true' ]; then
 else
   service httpd start
 fi
+
+IS_HTTPD_RUNNING=$(is_running nginx)
+if [ "$IS_HTTPD_RUNNING" == 'true' ]; then
+  service nginx restart
+else
+  service nginx start
+fi


### PR DESCRIPTION
フロントにnginxを構えて、imagesの参照のみassetsへ向けるように変更しました。

5/2(mon)16:00 修正を加えました。
apache側でアクセス元がnginxと認識してしまっていたのを修正しました。
nginxのrewriteの設定が誤っていたため、リバースプロキシが正しく設定出来ていなかった部分を修正しました。

参考ページ：

ヒアドキュメントでファイルを作成する
http://te2u.hatenablog.jp/entry/2015/07/01/224505

後方参照
http://hacknote.jp/archives/5035/

nginx+apacheリバースプロキシ
http://dev.classmethod.jp/server-side/server/nginx_reverse_proxy_apache/
http://qiita.com/skxeve/items/a20ca4baa027c5d48318

nginx rewrite設定
http://www2.matsue-ct.ac.jp/home/kanayama/text/nginx/node71.html
