### PR TITLE
課題05

### DIFF
--- a/05/Vagrantfile
+++ b/05/Vagrantfile
@@ -13,8 +13,6 @@ Vagrant.configure(2) do |config|
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-    v.check_guest_additions = false
-    v.functional_vboxsf     = false
     v.memory = $vm_memory
   end
 
@@ -23,4 +21,10 @@ Vagrant.configure(2) do |config|
   config.vm.network :private_network, ip: $vm_ip
 
   config.vm.synced_folder "./app", "/var/www/html", :type => "nfs"
+
+  config.vm.provision :shell, path: "scripts/build_tool.sh"
+  config.vm.provision :shell, path: "scripts/nginx.sh"
+  config.vm.provision :shell, path: "scripts/httpd.sh"
+  config.vm.provision :shell, path: "scripts/php.sh"
+  config.vm.provision :shell, path: "scripts/run.sh", run: "always"
 end

--- a/05/app/index.php
+++ b/05/app/index.php
@@ -1,0 +1,3 @@
+<?php
+echo '<img src="http://localhost:5001/assets/pray.jpg" />';
+

--- a/05/files/httpd.init
+++ b/05/files/httpd.init
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# httpd        Startup script for the Apache HTTP Server
+#
+# chkconfig: - 85 15
+# description: The Apache HTTP Server is an efficient and extensible  \
+#	       server implementing the current HTTP standards.
+# processname: httpd
+# config: /etc/httpd/conf/httpd.conf
+# config: /etc/sysconfig/httpd
+# pidfile: /var/run/httpd/httpd.pid
+#
+### BEGIN INIT INFO
+# Provides: httpd
+# Required-Start: $local_fs $remote_fs $network $named
+# Required-Stop: $local_fs $remote_fs $network
+# Should-Start: distcache
+# Short-Description: start and stop Apache HTTP Server
+# Description: The Apache HTTP Server is an extensible server 
+#  implementing the current HTTP standards.
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+if [ -f /etc/sysconfig/httpd ]; then
+        . /etc/sysconfig/httpd
+fi
+
+# Start httpd in the C locale by default.
+HTTPD_LANG=${HTTPD_LANG-"C"}
+
+# This will prevent initlog from swallowing up a pass-phrase prompt if
+# mod_ssl needs a pass-phrase from the user.
+INITLOG_ARGS=""
+
+# Set HTTPD=/etc/httpd/sbin/httpd.worker in /etc/sysconfig/httpd to use a server
+# with the thread-based "worker" MPM; BE WARNED that some modules may not
+# work correctly with a thread-based MPM; notably PHP will refuse to start.
+
+# Path to the apachectl script, server binary, and short-form for messages.
+apachectl=/etc/httpd/sbin/apachectl
+httpd=${HTTPD-/etc/httpd/sbin/httpd}
+prog=httpd
+pidfile=${PIDFILE-/etc/httpd/logs/httpd.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/httpd}
+RETVAL=0
+STOP_TIMEOUT=${STOP_TIMEOUT-10}
+
+# The semantics of these two functions differ from the way apachectl does
+# things -- attempting to start while running is a failure, and shutdown
+# when not running is also a failure.  So we just do it the way init scripts
+# are expected to behave here.
+start() {
+        echo -n $"Starting $prog: "
+        LANG=$HTTPD_LANG daemon --pidfile=${pidfile} $httpd $OPTIONS
+        RETVAL=$?
+        echo
+        [ $RETVAL = 0 ] && touch ${lockfile}
+        return $RETVAL
+}
+
+# When stopping httpd, a delay (of default 10 second) is required
+# before SIGKILLing the httpd parent; this gives enough time for the
+# httpd parent to SIGKILL any errant children.
+stop() {
+	echo -n $"Stopping $prog: "
+	killproc -p ${pidfile} -d ${STOP_TIMEOUT} $httpd
+	RETVAL=$?
+	echo
+	[ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+}
+reload() {
+    echo -n $"Reloading $prog: "
+    if ! LANG=$HTTPD_LANG $httpd $OPTIONS -t >&/dev/null; then
+        RETVAL=6
+        echo $"not reloading due to configuration syntax error"
+        failure $"not reloading $httpd due to configuration syntax error"
+    else
+        # Force LSB behaviour from killproc
+        LSB=1 killproc -p ${pidfile} $httpd -HUP
+        RETVAL=$?
+        if [ $RETVAL -eq 7 ]; then
+            failure $"httpd shutdown"
+        fi
+    fi
+    echo
+}
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+        status -p ${pidfile} $httpd
+	RETVAL=$?
+	;;
+  restart)
+	stop
+	start
+	;;
+  condrestart|try-restart)
+	if status -p ${pidfile} $httpd >&/dev/null; then
+		stop
+		start
+	fi
+	;;
+  force-reload|reload)
+        reload
+	;;
+  graceful|help|configtest|fullstatus)
+	$apachectl $@
+	RETVAL=$?
+	;;
+  *)
+	echo $"Usage: $prog {start|stop|restart|condrestart|try-restart|force-reload|reload|status|fullstatus|graceful|help|configtest}"
+	RETVAL=2
+esac
+
+exit $RETVAL

--- a/05/files/mod_proxy_fcgi.conf
+++ b/05/files/mod_proxy_fcgi.conf
@@ -1,0 +1,5 @@
+<IfModule proxy_fcgi_module>
+<FilesMatch \.php$>
+    SetHandler "proxy:unix:/var/run/php-fpm/php-fpm.sock|fcgi://localhost"
+</FilesMatch>
+</IfModule>

--- a/05/files/mod_remoteip.conf
+++ b/05/files/mod_remoteip.conf
@@ -1,0 +1,4 @@
+<IfModule remoteip_module>
+RemoteIPHeader X-Forwarded-For
+RemoteIPInternalProxy 127.0.0.1
+</IfModule>

--- a/05/files/nginx.conf
+++ b/05/files/nginx.conf
@@ -1,0 +1,54 @@
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+  
+  #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+  #                  '$status $body_bytes_sent "$http_referer" '
+  #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  #access_log  logs/access.log  main;
+
+  sendfile        on;
+  #tcp_nopush     on;
+
+  #keepalive_timeout  0;
+  keepalive_timeout  65;
+
+  #gzip  on;
+ 
+  upstream backend {
+    server localhost:9000;
+  }
+
+  server {
+    
+    listen       8080;
+    server_name  localhost;
+
+    location = /healthcheck {
+      add_header Content-Type text/plain;	
+      return 200 "OK";
+    }
+
+    location / {
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header    Host            $http_host;
+      proxy_pass http://backend;
+    }
+  }
+}

--- a/05/files/nginx.init
+++ b/05/files/nginx.init
@@ -1,0 +1,152 @@
+#!/bin/sh
+#
+# nginx        Startup script for nginx
+#
+# chkconfig: - 85 15
+# processname: nginx
+# config: /etc/nginx/nginx.conf
+# config: /etc/sysconfig/nginx
+# pidfile: /var/run/nginx.pid
+# description: nginx is an HTTP and reverse proxy server
+#
+### BEGIN INIT INFO
+# Provides: nginx
+# Required-Start: $local_fs $remote_fs $network
+# Required-Stop: $local_fs $remote_fs $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: start and stop nginx
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+if [ -L $0 ]; then
+    initscript=`/bin/readlink -f $0`
+else
+    initscript=$0
+fi
+
+sysconfig=`/bin/basename $initscript`
+
+if [ -f /etc/sysconfig/$sysconfig ]; then
+    . /etc/sysconfig/$sysconfig
+fi
+
+nginx=${NGINX-/usr/sbin/nginx}
+prog=`/bin/basename $nginx`
+conffile=${CONFFILE-/etc/nginx/nginx.conf}
+lockfile=${LOCKFILE-/var/lock/subsys/nginx}
+pidfile=${PIDFILE-/var/run/nginx.pid}
+SLEEPMSEC=${SLEEPMSEC-200000}
+UPGRADEWAITLOOPS=${UPGRADEWAITLOOPS-5}
+RETVAL=0
+
+start() {
+    echo -n $"Starting $prog: "
+
+    daemon --pidfile=${pidfile} ${nginx} -c ${conffile}
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && touch ${lockfile}
+    return $RETVAL
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p ${pidfile} ${prog}
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+}
+
+reload() {
+    echo -n $"Reloading $prog: "
+    killproc -p ${pidfile} ${prog} -HUP
+    RETVAL=$?
+    echo
+}
+
+upgrade() {
+    oldbinpidfile=${pidfile}.oldbin
+
+    configtest -q || return
+    echo -n $"Starting new master $prog: "
+    killproc -p ${pidfile} ${prog} -USR2
+    echo
+
+    for i in `/usr/bin/seq $UPGRADEWAITLOOPS`; do
+        /bin/usleep $SLEEPMSEC
+        if [ -f ${oldbinpidfile} -a -f ${pidfile} ]; then
+            echo -n $"Graceful shutdown of old $prog: "
+            killproc -p ${oldbinpidfile} ${prog} -QUIT
+            RETVAL=$?
+            echo
+            return
+        fi
+    done
+
+    echo $"Upgrade failed!"
+    RETVAL=1
+}
+
+configtest() {
+    if [ "$#" -ne 0 ] ; then
+        case "$1" in
+            -q)
+                FLAG=$1
+                ;;
+            *)
+                ;;
+        esac
+        shift
+    fi
+    ${nginx} -t -c ${conffile} $FLAG
+    RETVAL=$?
+    return $RETVAL
+}
+
+rh_status() {
+    status -p ${pidfile} ${nginx}
+}
+
+# See how we were called.
+case "$1" in
+    start)
+        rh_status >/dev/null 2>&1 && exit 0
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        rh_status
+        RETVAL=$?
+        ;;
+    restart)
+        configtest -q || exit $RETVAL
+        stop
+        start
+        ;;
+    upgrade)
+        rh_status >/dev/null 2>&1 || exit 0
+        upgrade
+        ;;
+    condrestart|try-restart)
+        if rh_status >/dev/null 2>&1; then
+            stop
+            start
+        fi
+        ;;
+    force-reload|reload)
+        reload
+        ;;
+    configtest)
+        configtest
+        ;;
+    *)
+        echo $"Usage: $prog {start|stop|restart|condrestart|try-restart|force-reload|upgrade|reload|status|help|configtest}"
+        RETVAL=2
+esac
+
+exit $RETVAL

--- a/05/files/php-fpm.init
+++ b/05/files/php-fpm.init
@@ -1,0 +1,111 @@
+#! /bin/sh
+#
+# chkconfig: - 84 16
+# description:	PHP FastCGI Process Manager
+# processname: php-fpm
+# config: /etc/php-fpm.conf
+# config: /etc/sysconfig/php-fpm
+# pidfile: /var/run/php-fpm/php-fpm.pid
+#
+### BEGIN INIT INFO
+# Provides: php-fpm
+# Required-Start: $local_fs $remote_fs $network $named
+# Required-Stop: $local_fs $remote_fs $network
+# Short-Description: start and stop PHP FPM
+# Description: PHP FastCGI Process Manager
+### END INIT INFO
+
+# Standard LSB functions
+#. /lib/lsb/init-functions
+
+# Source function library.
+. /etc/init.d/functions
+
+# Check that networking is up.
+. /etc/sysconfig/network
+
+# Additional environment file
+if [ -f /etc/sysconfig/php-fpm ]; then
+      . /etc/sysconfig/php-fpm
+fi
+
+if [ "$NETWORKING" = "no" ]
+then
+	exit 0
+fi
+
+RETVAL=0
+prog="php-fpm"
+pidfile=${PIDFILE-/var/run/php-fpm/php-fpm.pid}
+lockfile=${LOCKFILE-/var/lock/subsys/php-fpm}
+
+start () {
+	echo -n $"Starting $prog: "
+	dir=$(dirname ${pidfile})
+	[ -d $dir ] || mkdir $dir
+	daemon --pidfile ${pidfile} /usr/sbin/php-fpm --daemonize
+	RETVAL=$?
+	echo
+	[ $RETVAL -eq 0 ] && touch ${lockfile}
+}
+stop () {
+	echo -n $"Stopping $prog: "
+	killproc -p ${pidfile} php-fpm
+	RETVAL=$?
+	echo
+	if [ $RETVAL -eq 0 ] ; then
+		rm -f ${lockfile} ${pidfile}
+	fi
+}
+
+restart () {
+        stop
+        start
+}
+
+reload () {
+	echo -n $"Reloading $prog: "
+	if ! /usr/sbin/php-fpm --test ; then
+	        RETVAL=6
+	        echo $"not reloading due to configuration syntax error"
+	        failure $"not reloading $prog due to configuration syntax error"
+	else
+		killproc -p ${pidfile} php-fpm -USR2
+		RETVAL=$?
+	fi
+	echo
+}
+
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  status)
+	status -p ${pidfile} php-fpm
+	RETVAL=$?
+	;;
+  restart)
+	restart
+	;;
+  reload|force-reload)
+	reload
+	;;
+  configtest)
+ 	/usr/sbin/php-fpm --test
+	RETVAL=$?
+	;;
+  condrestart|try-restart)
+	[ -f ${lockfile} ] && restart || :
+	;;
+  *)
+	echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart|try-restart|configtest}"
+	RETVAL=2
+        ;;
+esac
+
+exit $RETVAL

--- a/05/scripts/build_tool.sh
+++ b/05/scripts/build_tool.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+yum -y update
+yum -y install gcc gcc-c++ autoconf
+

--- a/05/scripts/httpd.sh
+++ b/05/scripts/httpd.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -eu
+
+# install depend libs
+. /vagrant/scripts/lib.sh
+install_apr
+install_apr_util
+install_pcre
+install_openssl
+
+# httpd 
+_sysconfdir=/etc
+_prefix=/etc/httpd
+_bindir=/etc/httpd/bin
+_sbindir=/etc/httpd/sbin
+_mandir=/etc/httpd/man
+_libdir=/etc/httpd/lib
+_includedir=/etc/httpd/include
+contentdir=/etc/httpd/share
+apr_prefix=/usr/local/apr
+suexec_caller=apache
+docroot=/home
+_root_localstatedir=/var
+_localstatedir=/etc/httpd
+
+if [ ! -d /etc/httpd ]; then
+	pushd /usr/local/src
+	curl --remote-name http://ftp.tsukuba.wide.ad.jp/software/apache//httpd/httpd-2.4.20.tar.bz2
+	tar jxf httpd-2.4.20.tar.bz2 
+	
+	pushd httpd-2.4.20
+	./configure \
+		--prefix=${_sysconfdir}/httpd \
+		--exec-prefix=${_prefix} \
+		--bindir=${_bindir} \
+		--sbindir=${_sbindir} \
+		--mandir=${_mandir} \
+		--libdir=${_libdir} \
+		--sysconfdir=${_sysconfdir}/httpd/conf \
+		--includedir=${_includedir}/httpd \
+		--libexecdir=${_libdir}/httpd/modules \
+		--datadir=${contentdir} \
+		--with-installbuilddir=${_libdir}/httpd/build \
+		--enable-mpms-shared=all \
+		--with-apr=${apr_prefix} --with-apr-util=${apr_prefix} \
+		--with-pcre=/usr/local \
+		--enable-suexec --with-suexec \
+		--with-suexec-caller=${suexec_caller} \
+		--with-suexec-docroot=${docroot} \
+		--with-suexec-logfile=${_root_localstatedir}/log/httpd/suexec.log \
+		--with-suexec-bin=${_sbindir}/suexec \
+		--with-suexec-uidmin=500 --with-suexec-gidmin=100 \
+		--enable-pie \
+		--enable-mods-shared=all \
+		--enable-ssl --with-ssl=/usr/local/ssl --disable-distcache \
+		--enable-tlsv1x-thunks \
+		--enable-proxy \
+		--enable-cache \
+		--enable-disk-cache \
+		--enable-cgid --enable-cgi \
+		--enable-authn-anon --enable-authn-alias \
+		--disable-imagemap  \
+		--localstatedir=${_localstatedir}
+	make
+	make install
+	popd
+	popd
+fi
+/usr/sbin/useradd -c "Apache" -u 48 -s /sbin/nologin -r -d ${contentdir} apache 2> /dev/null || :
+
+cp /vagrant/files/httpd.init /etc/init.d/httpd
+cp /vagrant/files/mod_proxy_fcgi.conf /etc/httpd/conf/extra/mod_proxy_fcgi.conf
+cp /vagrant/files/mod_remoteip.conf /etc/httpd/conf/extra/mod_remoteip.conf
+
+CONF_PATH="/etc/httpd/conf/httpd.conf"
+sed -i -e "s/Listen 80$/Listen 9000/g" $CONF_PATH
+sed -i -e "s/User daemon$/User apache/g" $CONF_PATH
+sed -i -e "s/Group daemon$/User apache/g" $CONF_PATH
+sed -i -e "s/#ServerName www.example.com:80/ServerName localhost:9000/g" $CONF_PATH
+sed -i -e "s/#LoadModule slotmem_shm_module/LoadModule slotmem_shm_module/g" $CONF_PATH
+sed -i -e "s/#LoadModule remoteip_module/LoadModule remoteip_module/g" $CONF_PATH
+sed -i -e "s/#LoadModule include_module/LoadModule include_module/g" $CONF_PATH
+sed -i -e "s/DirectoryIndex index.html$/DirectoryIndex index.html index.php/g" $CONF_PATH
+sed -i -e "s|/etc/httpd/share/htdocs|/var/www/html|g" $CONF_PATH # DocumentRoot変更
+sed -i -e "s/LogFormat \"%h/LogFormat \"%a/g" $CONF_PATH # mod_remoteipではホスト名が書き換わらないのでログにはIPを記録する
+
+# 外部ファイルのinclude設定がなければ追加する
+COMMENT="# Include other conf"
+if ! grep -q "$COMMENT" "$CONF_PATH"; then
+cat << EOS >> "$CONF_PATH"
+$COMMENT
+Include conf/extra/mod_proxy_fcgi.conf
+Include conf/extra/mod_remoteip.conf
+
+EOS
+fi

--- a/05/scripts/lib.sh
+++ b/05/scripts/lib.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -eu
+
+function install_pcre() {
+  if [ ! -e /usr/local/bin/pcretest ]; then
+    pushd /usr/local/src
+    curl --remote-name ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.38.tar.gz
+    tar -xzvf pcre-8.38.tar.gz
+    pushd pcre-8.38
+    ./configure
+    make
+    make install
+    popd
+    popd
+  fi
+}
+
+function install_zlib() {
+  if [ ! -e /usr/local/lib/libz.so ]; then
+    pushd /usr/local/src
+    curl --remote-name http://zlib.net/zlib-1.2.8.tar.gz
+    tar -xzvf zlib-1.2.8.tar.gz
+    pushd zlib-1.2.8
+    ./configure
+    make
+    make install
+    popd
+    popd
+  fi
+}
+
+function install_openssl() {
+  if [ ! -d /usr/local/ssl ]; then
+    pushd /usr/local/src
+    curl --remote-name ftp://ftp.openssl.org/source/openssl-1.0.2h.tar.gz
+    tar -xzvf openssl-1.0.2h.tar.gz
+    pushd openssl-1.0.2h
+    ./config -fPIC shared
+    make
+    make install
+    popd
+    popd
+  fi
+}
+
+
+function install_apr() {
+  if [ ! -e /usr/local/apr/bin/apr-1-config ]; then
+    pushd /usr/local/src
+    curl --remote-name http://ftp.jaist.ac.jp/pub/apache/apr/apr-1.5.2.tar.gz
+    tar -xzvf apr-1.5.2.tar.gz
+    pushd apr-1.5.2
+    ./configure
+    make
+    make install
+    popd
+    popd
+  fi
+}
+
+function install_apr_util() {
+  install_apr
+
+  if [ ! -e /usr/local/apr/bin/apu-1-config ]; then
+    pushd /usr/local/src
+    curl --remote-name http://ftp.jaist.ac.jp/pub/apache/apr/apr-util-1.5.4.tar.gz
+    tar -xzvf apr-util-1.5.4.tar.gz
+    pushd apr-util-1.5.4
+    ./configure --with-apr=/usr/local/apr
+    make
+    make install
+    popd
+    popd
+  fi
+}
+
+function install_libxml2() {
+  if [ ! -L /usr/local/lib/libxml2.so ]; then
+    pushd /usr/local/src
+    curl --remote-name ftp://xmlsoft.org/libxml2/libxml2-2.9.3.tar.gz
+    tar -xzvf libxml2-2.9.3.tar.gz
+    pushd libxml2-2.9.3
+    ./configure --without-python
+    make
+    make install
+    popd
+    popd
+  fi
+}
+

--- a/05/scripts/nginx.sh
+++ b/05/scripts/nginx.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eu
+
+# install depend libs
+. /vagrant/scripts/lib.sh
+install_pcre
+install_zlib
+install_openssl
+
+# nginx
+_sysconfdir=/etc
+_sbindir=/usr/sbin
+_localstatedir=/var
+nginx_user=nginx
+nginx_group=nginx
+nginx_home=${_localstatedir}/cache/nginx
+if [ ! -d /etc/nginx ]; then
+	pushd /usr/local/src
+	curl --remote-name http://nginx.org/download/nginx-1.8.1.tar.gz
+	tar -xzvf nginx-1.8.1.tar.gz
+	
+	pushd nginx-1.8.1
+	./configure \
+		--prefix=${_sysconfdir}/nginx \
+		--sbin-path=${_sbindir}/nginx \
+		--conf-path=${_sysconfdir}/nginx/nginx.conf \
+		--error-log-path=${_localstatedir}/log/nginx/error.log \
+		--http-log-path=${_localstatedir}/log/nginx/access.log \
+		--pid-path=${_localstatedir}/run/nginx.pid \
+		--lock-path=${_localstatedir}/run/nginx.lock \
+		--http-client-body-temp-path=${_localstatedir}/cache/nginx/client_temp \
+		--http-proxy-temp-path=${_localstatedir}/cache/nginx/proxy_temp \
+		--http-fastcgi-temp-path=${_localstatedir}/cache/nginx/fastcgi_temp \
+		--http-uwsgi-temp-path=${_localstatedir}/cache/nginx/uwsgi_temp \
+		--http-scgi-temp-path=${_localstatedir}/cache/nginx/scgi_temp \
+		--user=${nginx_user} \
+		--group=${nginx_group} \
+		--with-http_ssl_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_stub_status_module \
+		--with-http_auth_request_module \
+		--with-mail \
+		--with-mail_ssl_module \
+		--with-file-aio \
+		--with-ipv6 \
+		--with-pcre=/usr/local/src/pcre-8.38 \
+		--with-zlib=/usr/local/src/zlib-1.2.8 \
+		--with-openssl=/usr/local/src/openssl-1.0.2h
+	make
+	make install
+	popd
+	popd
+fi
+getent group ${nginx_group} >/dev/null || groupadd -r ${nginx_group}
+getent passwd ${nginx_user} >/dev/null || \
+		useradd -r -g ${nginx_group} -s /sbin/nologin \
+		-d ${nginx_home} -c "nginx user"  ${nginx_user}
+mkdir -p ${_localstatedir}/cache/nginx
+
+cp /vagrant/files/nginx.conf /etc/nginx/nginx.conf
+cp /vagrant/files/nginx.init /etc/init.d/nginx

--- a/05/scripts/php.sh
+++ b/05/scripts/php.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -eu
+
+# install depend libs
+. /vagrant/scripts/lib.sh
+install_libxml2
+install_openssl
+install_pcre
+
+# php
+if [ ! -e /usr/sbin/php-fpm ]; then
+	pushd /usr/local/src
+	curl -L http://jp2.php.net/get/php-5.6.21.tar.gz/from/this/mirror > ./php-5.6.21.tar.gz
+	tar -xzvf php-5.6.21.tar.gz
+	
+	pushd php-5.6.21
+	_lib=/usr/lib64
+	_sysconfdir=/etc
+	_root_prefix=/usr
+	./configure \
+		--prefix=/usr \
+		--cache-file=../config.cache \
+		--with-libdir=${_lib} \
+		--sysconfdir=${_sysconfdir} \
+		--with-config-file-path=${_sysconfdir} \
+		--with-config-file-scan-dir=${_sysconfdir}/php.d \
+		--disable-debug \
+		--with-pic \
+		--disable-rpath \
+		--without-pear \
+		--without-gdbm \
+		--with-openssl-dir=/usr/local/ssl \
+		--with-system-ciphers \
+		--with-pcre-dir=/usr/local \
+		--with-zlib \
+		--with-layout=GNU \
+		--with-kerberos \
+		--with-libxml-dir=/usr/local \
+		--with-mhash \
+		--enable-fpm
+	make
+	make install
+	popd
+	popd
+fi
+
+cp /etc/php-fpm.conf.default /etc/php-fpm.conf
+cp /vagrant/files/php-fpm.init /etc/init.d/php-fpm
+
+sed -i -e "s/user = nobody$/user = apache/g" /etc/php-fpm.conf
+sed -i -e "s/group = nobody$/group = apache/g" /etc/php-fpm.conf
+sed -i -e "s|listen = 127.0.0.1:9000$|listen = /var/run/php-fpm/php-fpm.sock|g" /etc/php-fpm.conf
+sed -i -e "s/;listen.owner = nobody$/listen.owner = apache/g" /etc/php-fpm.conf
+sed -i -e "s/;listen.group = apache$/listen.group = apache/g" /etc/php-fpm.conf
+sed -i -e "s/;listen.mode = 0660$/listen.mode = 0660/g" /etc/php-fpm.conf
+sed -i -e "s|;pid = run/php-fpm.pid$|pid = /var/run/php-fpm/php-fpm.pid|g" /etc/php-fpm.conf
+sed -i -e "s|;error_log = log/php-fpm.log$|error_log = /var/log/php-fpm/error.log|g" /etc/php-fpm.conf
+mkdir -p /var/log/php-fpm
+

--- a/05/scripts/run.sh
+++ b/05/scripts/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eu
+
+function is_running() {
+	SERVICE_NAME=$1
+	IS_SERVICE_RUNNING=$(service $SERVICE_NAME status | grep "running")
+	if [ "$IS_SERVICE_RUNNING" == "" ]; then
+		echo 'false'
+	else
+		echo 'true'
+	fi
+}
+
+IS_PHPFPM_RUNNING=$(is_running php-fpm)
+if [ "$IS_PHPFPM_RUNNING" == 'true' ]; then
+  service php-fpm restart
+else
+  service php-fpm start
+fi
+
+IS_HTTPD_RUNNING=$(is_running httpd)
+if [ "$IS_HTTPD_RUNNING" == 'true' ]; then
+  service httpd restart
+else
+  service httpd start
+fi
+
+IS_NGINX_RUNNING=$(is_running nginx)
+if [ "$IS_NGINX_RUNNING" == 'true' ]; then
+  service nginx restart
+else
+  service nginx start
+fi
+


### PR DESCRIPTION
大森です。
課題05の実装が完了しました。
分量が多いですが、レビューをお願い致します。 :pray:

## 参考資料
### nginx
- configure, キックスクリプト、実行ユーザーははsrc.rpmを参考にしています。
http://nginx.org/packages/rhel/6/SRPMS/nginx-1.8.1-1.el6.ngx.src.rpm

- pcre
http://qiita.com/topology-lab/items/51f23feb422310b493c0

- nginx
https://librabuch.jp/blog/2013/01/nginx-install/

### apache
- configure, キックスクリプト、実行ユーザーはsrc.rpmを参考にしています。
http://vault.centos.org/6.7/SCL/Source/SPackages/httpd24-httpd-2.4.6-22.el6.centos.alt.src.rpm

- zlib
http://qiita.com/boscoworks/items/a27a74e5da8adc3c1be8

- openssl
http://stackoverflow.com/questions/2537271/compile-openssl-with-the-shared-option

- apr, apr-util
http://qiita.com/ksugawara61/items/70f5d1faf192c4ba6ca0
http://d.hatena.ne.jp/Kazuhira/20121117/1353159552

- apache
http://time-complexity.blogspot.jp/2013/11/apache-246.html
http://hb.matsumoto-r.jp/entry/2014/09/01/033038
http://qiita.com/shimoju/items/8e9c2a7bddd64e878799

### php

- configure, キックスクリプト、実行ユーザーははsrc.rpmを参考にしています。
http://rpms.famillecollet.com/SRPMS/php56-php-5.6.21-1.remi.src.rpm

- libxml2
https://mail.gnome.org/archives/xml/2013-May/msg00046.html


## PHPとApacheの連携に関して
- http://server-setting.info/centos/php_cgi_module_exchange.html
- http://server-setting.info/centos/apache-mod_fastcgi-php-fpm.html
- http://pocketstudio.jp/log3/2013/07/04/migration_mod_fcgid_to_mod_fastcgi/
- http://ymmt.hatenablog.com/entry/2014/10/24/154427

### PHP実行方式

候補
- モジュール 
- CGI
- FastCGI

PHPとApacheを疎結合にするためにモジュール起動は除外、
実行速度を優先してFastCGIを採用しました。

### FastCGIモジュール

候補
- mod_fastcgi
- mod_fcgid
- mod_proxy_fcgi

Apache2.4ではmod_proxy_fcgiが標準で利用出来るためこちらを採用しました。

